### PR TITLE
[WIP] Enhance ChatOps to work with multiple clouds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 *.json
 *install.yaml
 secrets.yaml
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# VMworld Dispatch Demo
+# Chat-ops Dispatch demo
 
 This guide walks through creation of a chat-ops integration with Slack using Dispatch.  Specifically we will be creating
-slack commands for interacting with VMware vCenter.
+slack commands for interacting with different clouds.
 
 ## Create Slack Incoming Webhook
 
-The incoming webhook will be used to asynchronously post vCenter status updates to a particular slack channel.  The
+The incoming webhook will be used to asynchronously post status updates to a particular slack channel.  The
 setup is pretty straightforward.
 
 [https://api.slack.com/incoming-webhooks](https://api.slack.com/incoming-webhooks)

--- a/aws.py
+++ b/aws.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#######################################################################
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#######################################################################
+
+import json
+
+import boto3
+
+
+def list_instances(ec2):
+    result = ec2.instances.filter(
+        Filters=[
+            {
+                'Name': 'tag:managedby',
+                'Values': ['cloudmaster']
+            }
+        ]
+    )
+    return [{
+            "id": i.id,
+            "name": [t["Value"] for t in i.tags if t["Key"] == "Name"][0],
+            "state": i.state["Name"],
+            } for i in result if i.state["Name"] != "terminated"]
+
+
+def create_instance(ec2, name):
+    result = ec2.create_instances(
+        MinCount=1, MaxCount=1, ImageId="ami-0f47ef92b4218ec09",
+        InstanceType="t1.micro",
+        TagSpecifications=[
+            {
+                'ResourceType': 'instance',
+                'Tags': [
+                    {
+                        'Key': 'managedby',
+                        'Value': 'cloudmaster'
+                    },
+                    {
+                        'Key': 'Name',
+                        'Value': name
+                    }
+                ]
+            }
+        ])
+    instance = result[0]
+    return {
+        "id": instance.id,
+        "name": name,
+    }
+
+
+def delete_instance(ec2_resource, ec2_client, name):
+    instances = ec2_resource.instances.filter(
+        Filters=[
+            {
+                'Name': 'tag:managedby',
+                'Values': ['cloudmaster']
+            },
+            {
+                'Name': "tag:Name",
+                'Values': [name]
+            }
+        ]
+    )
+    instanceIds = [i.id for i in instances]
+    print(instanceIds)
+    return ec2_client.terminate_instances(InstanceIds=instanceIds)
+
+
+def handle(ctx, payload):
+    """
+    entry point for GCP commands
+    """
+
+    access_key = ctx['secrets']['aws']['access_key']
+    secret_key = ctx['secrets']['aws']['secret_key']
+
+    ec2_resource = boto3.resource("ec2", aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    ec2_client = boto3.client("ec2", aws_access_key_id=access_key,
+                              aws_secret_access_key=secret_key)
+
+    if 'command' not in payload:
+        return _error('command is required')
+    command = payload['command']
+
+    result = {"error": "command {} is not supported".format(command)}
+    if command == 'create':
+        result = create_instance(ec2_resource, payload['name'])
+    if command == 'list':
+        result = list_instances(ec2_resource)
+    if command == 'delete':
+        result = delete_instance(ec2_resource, ec2_client, payload['name'])
+
+    return json.dumps(result)
+
+
+def _error(error_msg):
+    return json.dumps({
+        'error': error_msg
+    })
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open(sys.argv[1]) as p:
+        payload = json.load(p)
+
+    with open(sys.argv[2]) as s:
+        secrets = json.load(s)
+    ctx = {
+        "secrets": secrets
+    }
+    print("payload: ", payload, file=sys.stderr)
+    print("secrets: ", secrets, file=sys.stderr)
+    retval = handle(ctx, payload)
+    print(retval, file=sys.stdout)

--- a/azurecloud.py
+++ b/azurecloud.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+#######################################################################
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#######################################################################
+
+"""
+Example function to manage (create, delete, list) VMs in Azure.
+
+** REQUIREMENTS **
+
+* secret
+
+you can  obtain clientId, password and tenant when creating a service principal. you can create service principal
+in Azure by using Azure CLI:
+
+az ad sp create-for-rbac --name principalName --password "" # empty password will generate a random one
+
+Store all the required secrets in a JSON file.
+
+cat << EOF > azure.json
+{
+{
+    "clientId": "<UUID>",
+    "password": "<UUID>",
+    "tenant": "<UUID>",
+    "subscription": "<UUID>",
+    "admin_password": "<Password for admin account within a VM>",
+    "location": "<Azure region, e.g. useast2>",
+    "subnet": "<name of the subnet to connect VM to>",
+    "virtual_network": "<name of the virtual network where the subnet resides>"
+  }
+}
+EOF
+
+Create a secret:
+
+dispatch create secret azure azure.json
+
+* image
+
+Create requirements file:
+
+cat << EOF > requirements.txt
+azure==4.0.0
+EOF
+
+dispatch create base-image python3-base dispatchframework/python3-base:0.0.3 --language python3
+dispatch create image python-azure python3-base --runtime-deps requirements.txt
+
+Create a function:
+dispatch create function python-azure azure azurecloud.py --secret azure
+
+Execute it:
+dispatch exec azure --wait --input='{"command": "create","name": "exampleVM"}'
+
+"""
+
+import json
+import traceback
+
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.mgmt.network import NetworkManagementClient
+from azure.mgmt.compute import ComputeManagementClient
+
+from msrestazure.azure_exceptions import CloudError
+
+
+def get_credentials(client_id, secret, tenant):
+    """Creates Azure credentials object from string credentials"""
+
+    credentials = ServicePrincipalCredentials(
+        client_id=client_id,
+        secret=secret,
+        tenant=tenant
+    )
+    return credentials
+
+
+def list_instances(compute_client):
+    """Returns a list of instances managed by cloudmaster"""
+
+    return [{
+            "id": vm.id,
+            "name": vm.name,
+            "state": vm.provisioning_state,
+            "tags": vm.tags
+            } for vm in compute_client.virtual_machines.list_all()
+            if vm.tags and 'managedby' in vm.tags and vm.tags['managedby'] == 'cloudmaster']
+
+
+def create_nic(network_client, location, resource_group, virtual_network, subnet, vm_name):
+    """Creates a network interface required by a VM"""
+
+    subnet = network_client.subnets.get(resource_group, virtual_network, subnet)
+    async_nic_creation = network_client.network_interfaces.create_or_update(
+        resource_group,
+        "{}-nic".format(vm_name),
+        {
+            'location': location,
+            'ip_configurations': [{
+                'name': 'random_name',
+                'subnet': {
+                    'id': subnet.id
+                }
+            }]
+        }
+    )
+    return async_nic_creation.result(timeout=1)
+
+
+def delete_nic(network_client, resource_group, name):
+    """Delete network interface"""
+    network_client.network_interfaces.delete(resource_group, "{}-nic".format(name))
+
+
+def create_instance(compute_client, location, resource_group, nic, name, admin_password):
+    """Creates an Azure VM. expects Network interface to be pre-created."""
+    try:
+        vm_parameters = {
+            'location': location,
+            'hardware_profile': {
+                'vm_size': 'Standard_DS1_v2'
+            },
+            'tags': {
+                'managedby': 'cloudmaster'
+            },
+            'os_profile': {
+                'computer_name': name,
+                'admin_username': 'dispatch',
+                'admin_password': admin_password
+            },
+            'storage_profile': {
+                'image_reference': {
+                    'publisher': 'Canonical',
+                    'offer': 'UbuntuServer',
+                    'sku': '16.04.0-LTS',
+                    'version': 'latest'
+                },
+            },
+            'network_profile': {
+                'network_interfaces': [{
+                    'id': nic.id,
+                }]
+            },
+        }
+        async_vm_creation = compute_client.virtual_machines.create_or_update(
+            resource_group, name, vm_parameters)
+        vm = async_vm_creation.result(timeout=1)
+        return {
+            "id": vm.id,
+            "name": vm.name,
+            "state": vm.provisioning_state,
+            "tags": vm.tags
+        }
+    except CloudError:
+        return _error(traceback.format_exc())
+
+
+def delete_instance(compute_client, resource_group, name):
+    """Delete an instance"""
+    try:
+        async_vm_deletion = compute_client.virtual_machines.delete(resource_group, name)
+        return async_vm_deletion.result(timeout=1)
+    except CloudError:
+        return _error(traceback.format_exc())
+
+
+def _error(error_msg):
+    return json.dumps({
+        'error': error_msg
+    })
+
+
+def handle(ctx, payload):
+    """entrypoint for Azure operations """
+    resource_group = ctx['secrets']['resource_group']
+    location = ctx['secrets']['subscription']
+    subscription = ctx['secrets']['subscription']
+    admin_password = ctx['secrets']['admin_password']
+
+    credentials = get_credentials(client_id=ctx['secrets']['clientId'],
+                                  secret=ctx['secrets']['password'],
+                                  tenant=ctx['secrets']['tenant'])
+
+    compute_client = ComputeManagementClient(credentials, subscription)
+    network_client = NetworkManagementClient(credentials, subscription)
+
+    if 'command' not in payload:
+        return _error('command is required')
+    command = payload['command']
+
+    # default result is unsupported command
+    result = {"error": "command {} is not supported".format(command)}
+
+    if command == 'create':
+        if 'subnet' not in payload:
+            return _error('subnet is required')
+        subnet = payload['subnet']
+
+        if 'virtual_network' not in payload:
+            return _error('virtual network is required')
+        virtual_network = payload['virtual_network']
+
+        if 'name' not in payload:
+            return _error('vm name is required')
+        vm_name = payload['name']
+
+        nic = create_nic(network_client, location,resource_group, virtual_network, subnet, vm_name)
+        result = create_instance(compute_client, location, resource_group, nic, vm_name, admin_password)
+
+    if command == 'list':
+        result = list_instances(compute_client)
+
+    if command == 'delete':
+        result = delete_instance(compute_client, resource_group, payload['name'])
+        delete_nic(network_client, resource_group, payload['name'])
+
+    return json.dumps(result)
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open(sys.argv[1]) as p:
+        payload = json.load(p)
+
+    with open(sys.argv[2]) as s:
+        secrets = json.load(s)
+    ctx = {
+        "secrets": secrets
+    }
+    print("payload: ", payload, file=sys.stderr)
+    print("secrets: ", secrets, file=sys.stderr)
+    retval = handle(ctx, payload)
+    print(retval, file=sys.stdout)

--- a/gcp.py
+++ b/gcp.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+#######################################################################
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#######################################################################
+
+import time
+import json
+
+import googleapiclient.discovery
+from google.oauth2 import service_account
+
+
+def list_instances(compute, project, zone):
+    result = compute.instances().list(project=project, zone=zone, filter="labels.managedby=cloudmaster").execute()
+    if 'items' in result:
+        return result['items']
+    else:
+        return []
+
+
+def create_instance(compute, project, zone, name):
+    image_response = compute.images().getFromFamily(
+        project='debian-cloud', family='debian-9').execute()
+    source_disk_image = image_response['selfLink']
+
+    machine_type = "zones/%s/machineTypes/n1-standard-1" % zone
+
+    config = {
+        'name': name,
+        'machineType': machine_type,
+        'disks': [
+            {
+                'boot': True,
+                'autoDelete': True,
+                'initializeParams': {
+                    'sourceImage': source_disk_image,
+                }
+            }
+        ],
+        'networkInterfaces': [{
+            'network': 'global/networks/default',
+            'accessConfigs': [
+                {'type': 'ONE_TO_ONE_NAT', 'name': 'External NAT'}
+            ]
+        }],
+        'labels': {
+            'managedby': 'cloudmaster',
+        }
+    }
+
+    return compute.instances().insert(
+        project=project,
+        zone=zone,
+        body=config).execute()
+
+
+def delete_instance(compute, project, zone, name):
+    return compute.instances().delete(
+        project=project,
+        zone=zone,
+        instance=name).execute()
+
+
+# may not be needed
+def wait_for_operation(compute, project, zone, operation):
+    while True:
+        result = compute.zoneOperations().get(
+            project=project,
+            zone=zone,
+            operation=operation).execute()
+
+        if result['status'] == 'DONE':
+            if 'error' in result:
+                raise Exception(result['error'])
+            return result
+
+        time.sleep(1)
+
+
+def gcp_creds(secret):
+    return service_account.Credentials.from_service_account_info(json.loads(secret))
+
+
+def handle(ctx, payload):
+    """
+    entry point for GCP commands
+    """
+
+    creds = gcp_creds(json.dumps(ctx['secrets']))
+    zone = ctx['secrets']['zone']
+    project = ctx['secrets']['project_id']
+
+    compute = googleapiclient.discovery.build('compute', 'v1', credentials=creds, cache_discovery=False)
+
+    if 'command' not in payload:
+        return _error('command is required')
+    command = payload['command']
+
+    result = {"error": "command {} is not supported".format(command)}
+    if command == 'create':
+        result = create_instance(compute, project, zone, payload['name'])
+    if command == 'list':
+        result = list_instances(compute, project, zone)
+    if command == 'delete':
+        result = delete_instance(compute, project, zone, payload['name'])
+
+    return json.dumps(result)
+
+
+def _error(error_msg):
+    return json.dumps({
+            'error': error_msg
+        })
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open(sys.argv[1]) as p:
+        payload = json.load(p)
+
+    with open(sys.argv[2]) as s:
+        secrets = json.load(s)
+    ctx = {
+        "secrets": secrets
+    }
+    print("payload: ", payload, file=sys.stderr)
+    print("secrets: ", secrets, file=sys.stderr)
+    retval = handle(ctx, payload)
+    print(retval, file=sys.stdout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+azure==4.0.0
+boto3==1.9.25
+google-api-python-client==1.7.4
+requests==2.19.1
+pyvmomi

--- a/vsphere.py
+++ b/vsphere.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+#######################################################################
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#######################################################################
+
+"""
+Example function to manage (create, delete, list) VMs in Azure.
+
+** REQUIREMENTS **
+
+* secret
+
+you can  obtain clientId, password and tenant when creating a service principal. you can create service principal
+in Azure by using Azure CLI:
+
+az ad sp create-for-rbac --name principalName --password "" # empty password will generate a random one
+
+Store all the required secrets in a JSON file.
+
+cat << EOF > azure.json
+{
+{
+    "clientId": "<UUID>",
+    "password": "<UUID>",
+    "tenant": "<UUID>",
+    "subscription": "<UUID>",
+    "admin_password": "<Password for admin account within a VM>",
+    "location": "<Azure region, e.g. useast2>",
+    "subnet": "<name of the subnet to connect VM to>",
+    "virtual_network": "<name of the virtual network where the subnet resides>"
+  }
+}
+EOF
+
+Create a secret:
+
+dispatch create secret azure azure.json
+
+* image
+
+Create requirements file:
+
+cat << EOF > requirements.txt
+azure==4.0.0
+EOF
+
+dispatch create base-image python3-base dispatchframework/python3-base:0.0.3 --language python3
+dispatch create image python-azure python3-base --runtime-deps requirements.txt
+
+Create a function:
+dispatch create function python-azure azure azurecloud.py --secret azure
+
+Execute it:
+dispatch exec azure --wait --input='{"command": "create","name": "exampleVM"}'
+
+"""
+
+import json
+import ssl
+
+from pyVmomi import vim
+from pyVim.connect import SmartConnect, Disconnect
+
+
+def get_obj(content, vimtype, name):
+    """Return an object by name, if name is None the
+    first found object is returned
+    """
+    obj = None
+    container = content.viewManager.CreateContainerView(
+        content.rootFolder, vimtype, True)
+    for c in container.view:
+        if name:
+            if c.name == name:
+                obj = c
+                break
+        else:
+            obj = c
+            break
+    return obj
+
+
+def list_vms(vm_folder):
+    """Returns a list of instances managed by cloudmaster"""
+
+    return [
+        {
+            'name': vm.summary.config.name,
+            'id': vm.summary.config.instanceUuid,
+        }
+        for vm in vm_folder.childEntity]
+
+
+def create_vm(content, template, vm_name, datacenter_name, vm_folder, resource_pool, power_on):
+    """
+    Clone a VM from a template/VM, datacenter_name, vm_folder, datastore_name
+    cluster_name, resource_pool, and power_on are all optional.
+    """
+
+    # if none get the first one
+    datacenter = get_obj(content, [vim.Datacenter], datacenter_name)
+
+    if vm_folder:
+        destfolder = get_obj(content, [vim.Folder], vm_folder)
+    else:
+        destfolder = datacenter.vmFolder
+
+    resource_pool = get_obj(content, [vim.ResourcePool], resource_pool)
+
+    relospec = vim.vm.RelocateSpec()
+    relospec.datastore = template.datastore[0]
+    relospec.pool = resource_pool
+
+    clonespec = vim.vm.CloneSpec()
+    clonespec.location = relospec
+    clonespec.powerOn = power_on
+
+    print("creating VM...")
+    print("clone spec: %s" % clonespec)
+    task = template.Clone(folder=destfolder, name=vm_name, spec=clonespec)
+    return clonespec, task.info.state
+
+
+def delete_vm(content, name):
+    """Delete an instance"""
+    vm = get_obj(content, [vim.VirtualMachine], name)
+    if vm:
+        vm.Destroy_Task()
+    return {
+        'status': 'vm deletion started'
+    }
+
+
+def _error(error_msg):
+    return json.dumps({
+        'error': error_msg
+    })
+
+
+def handle(ctx, payload):
+    """entrypoint for vSphere operations"""
+
+    template_name = 'dispatch-photon'
+
+    secrets = ctx["secrets"]
+    if secrets is None:
+        raise Exception("Requires vsphere secrets")
+
+    host = secrets.get("host")
+    port = secrets.get("port", 443)
+    dc_name = secrets.get("datacenter")
+    vm_folder = secrets.get("vmFolder")
+    resource_pool = secrets.get("resourcePool")
+    username = secrets.get("username")
+    password = secrets.get("password", "")
+
+    vm_name = payload.get("name")
+    power_on = payload.get("powerOn", False)
+
+
+    if 'command' not in payload:
+        return _error('command is required')
+    command = payload['command']
+
+    # default result is unsupported command
+    result = {"error": "command {} is not supported".format(command)}
+
+    context = None
+    if hasattr(ssl, '_create_unverified_context'):
+        context = ssl._create_unverified_context()
+    si = SmartConnect(
+        host=host,
+        user=username,
+        pwd=password,
+        port=port,
+        sslContext=context)
+
+    content = si.RetrieveContent()
+
+    if command == 'create':
+        template = get_obj(content, [vim.VirtualMachine], template_name)
+        if template is None:
+            _error("template not found")
+            return
+        _, result = create_vm(content, template, vm_name, dc_name, vm_folder, resource_pool, power_on)
+
+    if command == 'list':
+        folder = get_obj(content, [vim.Folder], vm_folder)
+        result = list_vms(folder)
+
+    if command == 'delete':
+        result = delete_vm(content, vm_name)
+
+    Disconnect(si)
+
+    return json.dumps(result)
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open(sys.argv[1]) as p:
+        payload = json.load(p)
+
+    with open(sys.argv[2]) as s:
+        secrets = json.load(s)
+    ctx = {
+        "secrets": secrets
+    }
+    print("payload: ", payload, file=sys.stderr)
+    print("secrets: ", secrets, file=sys.stderr)
+    retval = handle(ctx, payload)
+    print(retval, file=sys.stdout)


### PR DESCRIPTION
## TODO
- [ ] Reflect changes in README
- [ ] Add support for VMC
- [ ] Add examples in other languages

##  Changes
* adds support for AWS, GCP and Azure
* adds support for `create`, `list`, `delete` commands

Example:
To create an instance on all clouds at the same time, the command would be:
`/cloudmaster create myVM on all`

switch `all` to `gcp`, `azure` or `aws` to deploy only to selected
cloud.